### PR TITLE
Add catalog data persistence classes

### DIFF
--- a/CatalogNote/CatalogNote.csproj
+++ b/CatalogNote/CatalogNote.csproj
@@ -53,6 +53,8 @@
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
     <Compile Include="Program.cs" />
+    <Compile Include="Entities.cs" />
+    <Compile Include="DataStorage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/CatalogNote/DataStorage.cs
+++ b/CatalogNote/DataStorage.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization.Json;
+
+namespace CatalogNote
+{
+    internal static class DataStorage
+    {
+        private static readonly string FilePath =
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "catalog.json");
+
+        public static CatalogData Load()
+        {
+            if (!File.Exists(FilePath))
+                return new CatalogData();
+
+            using (FileStream fs = File.OpenRead(FilePath))
+            {
+                var serializer = new DataContractJsonSerializer(typeof(CatalogData));
+                return (CatalogData)serializer.ReadObject(fs);
+            }
+        }
+
+        public static void Save(CatalogData data)
+        {
+            using (FileStream fs = File.Create(FilePath))
+            {
+                var serializer = new DataContractJsonSerializer(typeof(CatalogData));
+                serializer.WriteObject(fs, data);
+            }
+        }
+    }
+}

--- a/CatalogNote/Entities.cs
+++ b/CatalogNote/Entities.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace CatalogNote
+{
+    [DataContract]
+    public class Student
+    {
+        [DataMember]
+        public int Id { get; set; }
+
+        [DataMember]
+        public string Name { get; set; }
+    }
+
+    [DataContract]
+    public class Disciplina
+    {
+        [DataMember]
+        public int Id { get; set; }
+
+        [DataMember]
+        public string Name { get; set; }
+    }
+
+    [DataContract]
+    public class Nota
+    {
+        [DataMember]
+        public int StudentId { get; set; }
+
+        [DataMember]
+        public int DisciplinaId { get; set; }
+
+        [DataMember]
+        public double Value { get; set; }
+    }
+
+    [DataContract]
+    public class CatalogData
+    {
+        [DataMember]
+        public List<Student> Students { get; set; } = new List<Student>();
+
+        [DataMember]
+        public List<Disciplina> Discipline { get; set; } = new List<Disciplina>();
+
+        [DataMember]
+        public List<Nota> Notes { get; set; } = new List<Nota>();
+    }
+}

--- a/CatalogNote/Program.cs
+++ b/CatalogNote/Program.cs
@@ -8,15 +8,24 @@ namespace CatalogNote
 {
     internal static class Program
     {
+        public static CatalogData Catalog { get; private set; }
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
+            Catalog = DataStorage.Load();
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            Application.ApplicationExit += OnApplicationExit;
             Application.Run(new Form1());
+        }
+
+        private static void OnApplicationExit(object sender, EventArgs e)
+        {
+            DataStorage.Save(Catalog);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add student, discipline and grade model classes
- serialize catalog data to a JSON file using `DataContractJsonSerializer`
- load the catalog at startup and save on exit

## Testing
- `dotnet build CatalogNote.sln -c Release` *(fails: reference assemblies for .NET Framework 4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af1fd2eb083278b67071646fee62f