### PR TITLE
Add serialization references

### DIFF
--- a/CatalogNote/CatalogNote.csproj
+++ b/CatalogNote/CatalogNote.csproj
@@ -44,6 +44,8 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Json" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Form1.cs">


### PR DESCRIPTION
## Summary
- add references to System.Runtime.Serialization and System.Runtime.Serialization.Json

## Testing
- `dotnet build CatalogNote.csproj` *(fails: reference assemblies for .NETFramework 4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afd6700fc8327900bb930307db86b