### PR TITLE
Add CRUD forms and CSV export

### DIFF
--- a/CatalogNote/CatalogNote.csproj
+++ b/CatalogNote/CatalogNote.csproj
@@ -54,6 +54,24 @@
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="StudentsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="StudentsForm.Designer.cs">
+      <DependentUpon>StudentsForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="DisciplineForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="DisciplineForm.Designer.cs">
+      <DependentUpon>DisciplineForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="NotesForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="NotesForm.Designer.cs">
+      <DependentUpon>NotesForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="StatisticsForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -61,6 +79,7 @@
       <DependentUpon>StatisticsForm.cs</DependentUpon>
     </Compile>
     <Compile Include="CatalogLogic.cs" />
+    <Compile Include="CsvExporter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Entities.cs" />
     <Compile Include="DataStorage.cs" />

--- a/CatalogNote/CsvExporter.cs
+++ b/CatalogNote/CsvExporter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace CatalogNote
+{
+    internal static class CsvExporter
+    {
+        public static void Export(string path)
+        {
+            using (var writer = new StreamWriter(path))
+            {
+                writer.WriteLine("Student,Discipline,Grade,Date");
+                foreach (var note in Program.Catalog.Notes)
+                {
+                    var student = Program.Catalog.Students.FirstOrDefault(s => s.Id == note.StudentId);
+                    var discipline = Program.Catalog.Discipline.FirstOrDefault(d => d.Id == note.DisciplinaId);
+                    writer.WriteLine($"{student?.DisplayName},{discipline?.Name},{note.Value},{note.Date:yyyy-MM-dd}");
+                }
+            }
+        }
+    }
+}
+

--- a/CatalogNote/DisciplineForm.Designer.cs
+++ b/CatalogNote/DisciplineForm.Designer.cs
@@ -1,0 +1,68 @@
+namespace CatalogNote
+{
+    partial class DisciplineForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.DataGridView dataGridView1;
+        private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnDelete;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnDelete = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.SuspendLayout();
+            // dataGridView1
+            this.dataGridView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                        | System.Windows.Forms.AnchorStyles.Left)
+                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridView1.Location = new System.Drawing.Point(12, 12);
+            this.dataGridView1.Name = "dataGridView1";
+            this.dataGridView1.Size = new System.Drawing.Size(560, 308);
+            this.dataGridView1.TabIndex = 0;
+            // btnAdd
+            this.btnAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnAdd.Location = new System.Drawing.Point(12, 326);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(75, 23);
+            this.btnAdd.TabIndex = 1;
+            this.btnAdd.Text = "Add";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // btnDelete
+            this.btnDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnDelete.Location = new System.Drawing.Point(93, 326);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(75, 23);
+            this.btnDelete.TabIndex = 2;
+            this.btnDelete.Text = "Delete";
+            this.btnDelete.UseVisualStyleBackColor = true;
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            // DisciplineForm
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(584, 361);
+            this.Controls.Add(this.btnDelete);
+            this.Controls.Add(this.btnAdd);
+            this.Controls.Add(this.dataGridView1);
+            this.Name = "DisciplineForm";
+            this.Text = "Discipline";
+            this.Load += new System.EventHandler(this.DisciplineForm_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.ResumeLayout(false);
+        }
+    }
+}
+

--- a/CatalogNote/DisciplineForm.cs
+++ b/CatalogNote/DisciplineForm.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace CatalogNote
+{
+    public partial class DisciplineForm : Form
+    {
+        private BindingList<Disciplina> _discipline;
+
+        public DisciplineForm()
+        {
+            InitializeComponent();
+        }
+
+        private void DisciplineForm_Load(object sender, EventArgs e)
+        {
+            _discipline = new BindingList<Disciplina>(Program.Catalog.Discipline);
+            dataGridView1.AutoGenerateColumns = true;
+            dataGridView1.DataSource = _discipline;
+        }
+
+        private void btnAdd_Click(object sender, EventArgs e)
+        {
+            int nextId = _discipline.Any() ? _discipline.Max(d => d.Id) + 1 : 1;
+            _discipline.Add(new Disciplina { Id = nextId });
+        }
+
+        private void btnDelete_Click(object sender, EventArgs e)
+        {
+            foreach (DataGridViewRow row in dataGridView1.SelectedRows)
+            {
+                if (row.DataBoundItem is Disciplina d)
+                    _discipline.Remove(d);
+            }
+        }
+    }
+}
+

--- a/CatalogNote/Entities.cs
+++ b/CatalogNote/Entities.cs
@@ -11,7 +11,18 @@ namespace CatalogNote
         public int Id { get; set; }
 
         [DataMember]
-        public string Name { get; set; }
+        public string LastName { get; set; }
+
+        [DataMember]
+        public string FirstName { get; set; }
+
+        [DataMember]
+        public string Email { get; set; }
+
+        [DataMember]
+        public string Group { get; set; }
+
+        public string DisplayName => $"{LastName} {FirstName}";
     }
 
     [DataContract]
@@ -22,11 +33,20 @@ namespace CatalogNote
 
         [DataMember]
         public string Name { get; set; }
+
+        [DataMember]
+        public string Acronym { get; set; }
+
+        [DataMember]
+        public string EvaluationType { get; set; }
     }
 
     [DataContract]
     public class Nota
     {
+        [DataMember]
+        public int Id { get; set; }
+
         [DataMember]
         public int StudentId { get; set; }
 
@@ -35,6 +55,9 @@ namespace CatalogNote
 
         [DataMember]
         public double Value { get; set; }
+
+        [DataMember]
+        public DateTime Date { get; set; }
     }
 
     [DataContract]

--- a/CatalogNote/Form1.Designer.cs
+++ b/CatalogNote/Form1.Designer.cs
@@ -30,6 +30,10 @@
         {
             this.components = new System.ComponentModel.Container();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.studentsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.disciplineMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.notesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statisticsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -37,6 +41,10 @@
             // menuStrip1
             // 
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.studentsMenuItem,
+            this.disciplineMenuItem,
+            this.notesMenuItem,
+            this.exportMenuItem,
             this.statisticsMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
@@ -44,8 +52,36 @@
             this.menuStrip1.TabIndex = 0;
             this.menuStrip1.Text = "menuStrip1";
             // 
+            // studentsMenuItem
+            //
+            this.studentsMenuItem.Name = "studentsMenuItem";
+            this.studentsMenuItem.Size = new System.Drawing.Size(65, 20);
+            this.studentsMenuItem.Text = "Students";
+            this.studentsMenuItem.Click += new System.EventHandler(this.studentsMenuItem_Click);
+            //
+            // disciplineMenuItem
+            //
+            this.disciplineMenuItem.Name = "disciplineMenuItem";
+            this.disciplineMenuItem.Size = new System.Drawing.Size(75, 20);
+            this.disciplineMenuItem.Text = "Discipline";
+            this.disciplineMenuItem.Click += new System.EventHandler(this.disciplineMenuItem_Click);
+            //
+            // notesMenuItem
+            //
+            this.notesMenuItem.Name = "notesMenuItem";
+            this.notesMenuItem.Size = new System.Drawing.Size(49, 20);
+            this.notesMenuItem.Text = "Notes";
+            this.notesMenuItem.Click += new System.EventHandler(this.notesMenuItem_Click);
+            //
+            // exportMenuItem
+            //
+            this.exportMenuItem.Name = "exportMenuItem";
+            this.exportMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.exportMenuItem.Text = "Export";
+            this.exportMenuItem.Click += new System.EventHandler(this.exportMenuItem_Click);
+            //
             // statisticsMenuItem
-            // 
+            //
             this.statisticsMenuItem.Name = "statisticsMenuItem";
             this.statisticsMenuItem.Size = new System.Drawing.Size(65, 20);
             this.statisticsMenuItem.Text = "Statistics";
@@ -69,6 +105,10 @@
         #endregion
 
         private System.Windows.Forms.MenuStrip menuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem studentsMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem disciplineMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem notesMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportMenuItem;
         private System.Windows.Forms.ToolStripMenuItem statisticsMenuItem;
     }
 }

--- a/CatalogNote/Form1.cs
+++ b/CatalogNote/Form1.cs
@@ -17,6 +17,43 @@ namespace CatalogNote
             InitializeComponent();
         }
 
+        private void studentsMenuItem_Click(object sender, EventArgs e)
+        {
+            using (var form = new StudentsForm())
+            {
+                form.ShowDialog();
+            }
+        }
+
+        private void disciplineMenuItem_Click(object sender, EventArgs e)
+        {
+            using (var form = new DisciplineForm())
+            {
+                form.ShowDialog();
+            }
+        }
+
+        private void notesMenuItem_Click(object sender, EventArgs e)
+        {
+            using (var form = new NotesForm())
+            {
+                form.ShowDialog();
+            }
+        }
+
+        private void exportMenuItem_Click(object sender, EventArgs e)
+        {
+            using (var sfd = new SaveFileDialog())
+            {
+                sfd.Filter = "CSV files (*.csv)|*.csv";
+                if (sfd.ShowDialog() == DialogResult.OK)
+                {
+                    CsvExporter.Export(sfd.FileName);
+                    MessageBox.Show("Export completed.");
+                }
+            }
+        }
+
         private void statisticsMenuItem_Click(object sender, EventArgs e)
         {
             using (var form = new StatisticsForm())

--- a/CatalogNote/NotesForm.Designer.cs
+++ b/CatalogNote/NotesForm.Designer.cs
@@ -1,0 +1,68 @@
+namespace CatalogNote
+{
+    partial class NotesForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.DataGridView dataGridView1;
+        private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnDelete;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnDelete = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.SuspendLayout();
+            // dataGridView1
+            this.dataGridView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                        | System.Windows.Forms.AnchorStyles.Left)
+                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridView1.Location = new System.Drawing.Point(12, 12);
+            this.dataGridView1.Name = "dataGridView1";
+            this.dataGridView1.Size = new System.Drawing.Size(560, 308);
+            this.dataGridView1.TabIndex = 0;
+            // btnAdd
+            this.btnAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnAdd.Location = new System.Drawing.Point(12, 326);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(75, 23);
+            this.btnAdd.TabIndex = 1;
+            this.btnAdd.Text = "Add";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // btnDelete
+            this.btnDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnDelete.Location = new System.Drawing.Point(93, 326);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(75, 23);
+            this.btnDelete.TabIndex = 2;
+            this.btnDelete.Text = "Delete";
+            this.btnDelete.UseVisualStyleBackColor = true;
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            // NotesForm
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(584, 361);
+            this.Controls.Add(this.btnDelete);
+            this.Controls.Add(this.btnAdd);
+            this.Controls.Add(this.dataGridView1);
+            this.Name = "NotesForm";
+            this.Text = "Notes";
+            this.Load += new System.EventHandler(this.NotesForm_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.ResumeLayout(false);
+        }
+    }
+}
+

--- a/CatalogNote/NotesForm.cs
+++ b/CatalogNote/NotesForm.cs
@@ -1,0 +1,62 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace CatalogNote
+{
+    public partial class NotesForm : Form
+    {
+        private BindingList<Nota> _notes;
+
+        public NotesForm()
+        {
+            InitializeComponent();
+        }
+
+        private void NotesForm_Load(object sender, EventArgs e)
+        {
+            _notes = new BindingList<Nota>(Program.Catalog.Notes);
+            dataGridView1.AutoGenerateColumns = false;
+
+            var colId = new DataGridViewTextBoxColumn { DataPropertyName = "Id", HeaderText = "Id" };
+            var colStudent = new DataGridViewComboBoxColumn
+            {
+                DataPropertyName = "StudentId",
+                DataSource = Program.Catalog.Students,
+                DisplayMember = "DisplayName",
+                ValueMember = "Id",
+                HeaderText = "Student"
+            };
+            var colDiscipline = new DataGridViewComboBoxColumn
+            {
+                DataPropertyName = "DisciplinaId",
+                DataSource = Program.Catalog.Discipline,
+                DisplayMember = "Name",
+                ValueMember = "Id",
+                HeaderText = "Discipline"
+            };
+            var colValue = new DataGridViewTextBoxColumn { DataPropertyName = "Value", HeaderText = "Grade" };
+            var colDate = new DataGridViewTextBoxColumn { DataPropertyName = "Date", HeaderText = "Date" };
+
+            dataGridView1.Columns.AddRange(colId, colStudent, colDiscipline, colValue, colDate);
+            dataGridView1.DataSource = _notes;
+        }
+
+        private void btnAdd_Click(object sender, EventArgs e)
+        {
+            int nextId = _notes.Any() ? _notes.Max(n => n.Id) + 1 : 1;
+            _notes.Add(new Nota { Id = nextId, Date = DateTime.Now });
+        }
+
+        private void btnDelete_Click(object sender, EventArgs e)
+        {
+            foreach (DataGridViewRow row in dataGridView1.SelectedRows)
+            {
+                if (row.DataBoundItem is Nota n)
+                    _notes.Remove(n);
+            }
+        }
+    }
+}
+

--- a/CatalogNote/StatisticsForm.cs
+++ b/CatalogNote/StatisticsForm.cs
@@ -15,7 +15,7 @@ namespace CatalogNote
         private void StatisticsForm_Load(object sender, EventArgs e)
         {
             cbStudent.DataSource = Program.Catalog.Students;
-            cbStudent.DisplayMember = "Name";
+            cbStudent.DisplayMember = "DisplayName";
             cbStudent.ValueMember = "Id";
 
             cbDiscipline.DataSource = Program.Catalog.Discipline;
@@ -54,9 +54,10 @@ namespace CatalogNote
 
             var table = notes.Select(n => new
             {
-                Student = Program.Catalog.Students.First(st => st.Id == n.StudentId).Name,
+                Student = Program.Catalog.Students.First(st => st.Id == n.StudentId).DisplayName,
                 Discipline = Program.Catalog.Discipline.First(d => d.Id == n.DisciplinaId).Name,
-                Grade = n.Value
+                Grade = n.Value,
+                Date = n.Date.ToString("yyyy-MM-dd")
             }).ToList();
 
             dataGridView1.DataSource = table;

--- a/CatalogNote/StudentsForm.Designer.cs
+++ b/CatalogNote/StudentsForm.Designer.cs
@@ -1,0 +1,68 @@
+namespace CatalogNote
+{
+    partial class StudentsForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.DataGridView dataGridView1;
+        private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnDelete;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnDelete = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            this.SuspendLayout();
+            // dataGridView1
+            this.dataGridView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                        | System.Windows.Forms.AnchorStyles.Left)
+                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridView1.Location = new System.Drawing.Point(12, 12);
+            this.dataGridView1.Name = "dataGridView1";
+            this.dataGridView1.Size = new System.Drawing.Size(560, 308);
+            this.dataGridView1.TabIndex = 0;
+            // btnAdd
+            this.btnAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnAdd.Location = new System.Drawing.Point(12, 326);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(75, 23);
+            this.btnAdd.TabIndex = 1;
+            this.btnAdd.Text = "Add";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // btnDelete
+            this.btnDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnDelete.Location = new System.Drawing.Point(93, 326);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(75, 23);
+            this.btnDelete.TabIndex = 2;
+            this.btnDelete.Text = "Delete";
+            this.btnDelete.UseVisualStyleBackColor = true;
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            // StudentsForm
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(584, 361);
+            this.Controls.Add(this.btnDelete);
+            this.Controls.Add(this.btnAdd);
+            this.Controls.Add(this.dataGridView1);
+            this.Name = "StudentsForm";
+            this.Text = "Students";
+            this.Load += new System.EventHandler(this.StudentsForm_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            this.ResumeLayout(false);
+        }
+    }
+}
+

--- a/CatalogNote/StudentsForm.cs
+++ b/CatalogNote/StudentsForm.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace CatalogNote
+{
+    public partial class StudentsForm : Form
+    {
+        private BindingList<Student> _students;
+
+        public StudentsForm()
+        {
+            InitializeComponent();
+        }
+
+        private void StudentsForm_Load(object sender, EventArgs e)
+        {
+            _students = new BindingList<Student>(Program.Catalog.Students);
+            dataGridView1.AutoGenerateColumns = true;
+            dataGridView1.DataSource = _students;
+        }
+
+        private void btnAdd_Click(object sender, EventArgs e)
+        {
+            int nextId = _students.Any() ? _students.Max(s => s.Id) + 1 : 1;
+            _students.Add(new Student { Id = nextId });
+        }
+
+        private void btnDelete_Click(object sender, EventArgs e)
+        {
+            foreach (DataGridViewRow row in dataGridView1.SelectedRows)
+            {
+                if (row.DataBoundItem is Student s)
+                    _students.Remove(s);
+            }
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## Overview
 
-CatalogNote is a Windows Forms application targeting **.NET Framework 4.7.2**. The solution currently contains only the default `Form1` with no additional logic. Running the application simply opens this blank form.
+CatalogNote is a Windows Forms application targeting **.NET Framework 4.7.2**. The application manages students, disciplines and grades using a local JSON file.
+
+Features include:
+
+- CRUD operations for students, disciplines and notes;
+- Viewing statistics such as averages and pass/fail status;
+- Exporting the catalog to CSV.
 
 ## Building on Windows
 
@@ -19,5 +25,5 @@ The solution file `CatalogNote.sln` is located in the repository root.
 
 ## Building on Non‑Windows Platforms
 
-The project targets the classic .NET Framework. Building on platforms other than Windows requires the reference assemblies for .NET Framework 4.7.2 to be installed or the project updated to multi‑target .NET Core/5+ in addition to .NET Framework.
+The project targets the classic .NET Framework. On Linux, Mono's `xbuild` can be used to build the project after installing the `mono-complete` package.
 


### PR DESCRIPTION
## Summary
- extend entity models with all required fields
- add forms for managing students, disciplines and notes
- implement CSV export and add menu commands
- update statistics screen for new entity fields
- document new features in README

## Testing
- `xbuild CatalogNote.sln /p:Configuration=Debug`

------
https://chatgpt.com/codex/tasks/task_e_684b00f785ac8327a6c93e23646c60ce